### PR TITLE
Update binary to v0.5.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,11 @@
 var path = require('path');
 var BinWrapper = require('bin-wrapper');
 
-var VERSION = '0.4.0';
+var VERSION = '0.5.0';
 var BASE = 'https://github.com/facebook/flow/releases/download/v' + VERSION + '/';
 
 module.exports = new BinWrapper()
-	.src(BASE + 'flow-osx-latest.zip', 'darwin')
-	.src(BASE + 'flow-linux64-latest.zip', 'linux', 'x64')
+	.src(BASE + 'flow-osx-v' + VERSION + '.zip', 'darwin')
+	.src(BASE + 'flow-linux64-v' + VERSION + '.zip', 'linux', 'x64')
 	.dest(path.join(__dirname, '../vendor'))
 	.use('flow');


### PR DESCRIPTION
Sorry that I screwed up the binary names for 0.4.0. I've kept those messed up binary names for 0.4.0 and I added properly versioned binaries for 0.4.0 as well: https://github.com/facebook/flow/releases/tag/v0.4.0